### PR TITLE
Get rid of "engines" property

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,10 +56,5 @@
     ],
     "exec": "npm run build",
     "ext": "ts"
-  },
-  "engines": {
-    "npm": "*",
-    "yarn": "please-use-npm",
-    "pnpm": "please-use-npm"
   }
 }


### PR DESCRIPTION
Everyone should be able to use their own package manager.