### PR TITLE
feature: add ESModule support

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,19 +1,14 @@
 module.exports = {
     env: {
-        'browser': true,
         'node': true,
     },
     parser: '@typescript-eslint/parser',
-    parserOptions: { 
-        'ecmaVersion': 12,
-        'sourceType': 'module',
-    },
     plugins: [
         'jest',
         '@typescript-eslint'
     ],
     extends: [
-        'eslint:recommended', 
+        'eslint:recommended',
         'plugin:jest/recommended',
         'plugin:@typescript-eslint/recommended',
     ],

--- a/.npmignore
+++ b/.npmignore
@@ -3,4 +3,3 @@
 
 # Allow dist folder
 !dist
-!umd.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.0.4",
       "license": "MIT",
       "devDependencies": {
+        "@rollup/plugin-typescript": "^8.1.1",
         "@types/jest": "^26.0.14",
         "@typescript-eslint/eslint-plugin": "^4.14.1",
         "@typescript-eslint/parser": "^4.14.1",
@@ -832,6 +833,41 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@rollup/plugin-typescript": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-8.1.1.tgz",
+      "integrity": "sha512-DPFy0SV8/GgHFL31yPFVo0G1T3yzwdw6R9KisBfO2zCYbDHUqDChSWr1KmtpGz/TmutpoGJjIvu80p9HzCEF0A==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/pluginutils": "^3.1.0",
+        "resolve": "^1.17.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.14.0",
+        "tslib": "*",
+        "typescript": ">=3.4.0"
+      }
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+      "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "0.0.39",
+        "estree-walker": "^1.0.1",
+        "picomatch": "^2.2.2"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0"
+      }
+    },
     "node_modules/@sindresorhus/is": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
@@ -911,6 +947,12 @@
       "dependencies": {
         "@babel/types": "^7.3.0"
       }
+    },
+    "node_modules/@types/estree": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+      "dev": true
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.4",
@@ -2743,6 +2785,12 @@
       "engines": {
         "node": ">=4.0"
       }
+    },
+    "node_modules/estree-walker": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+      "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+      "dev": true
     },
     "node_modules/esutils": {
       "version": "2.0.3",
@@ -8674,6 +8722,27 @@
         "fastq": "^1.6.0"
       }
     },
+    "@rollup/plugin-typescript": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-8.1.1.tgz",
+      "integrity": "sha512-DPFy0SV8/GgHFL31yPFVo0G1T3yzwdw6R9KisBfO2zCYbDHUqDChSWr1KmtpGz/TmutpoGJjIvu80p9HzCEF0A==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^3.1.0",
+        "resolve": "^1.17.0"
+      }
+    },
+    "@rollup/pluginutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+      "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "0.0.39",
+        "estree-walker": "^1.0.1",
+        "picomatch": "^2.2.2"
+      }
+    },
     "@sindresorhus/is": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
@@ -8747,6 +8816,12 @@
       "requires": {
         "@babel/types": "^7.3.0"
       }
+    },
+    "@types/estree": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+      "dev": true
     },
     "@types/graceful-fs": {
       "version": "4.1.4",
@@ -10155,6 +10230,12 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true
+    },
+    "estree-walker": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+      "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
       "dev": true
     },
     "esutils": {

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "@schotsl/uwuifier",
   "version": "2.0.4",
-  "main": "dist/index.js",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "unpkg": "dist/index.js",
   "types": "dist/index.d.js",
-  "unpkg": "dist/index.umd.js",
   "author": "Sjors van Holst",
   "license": "MIT",
   "homepage": "https://github.com/Schotsl/uwuifier#readme",
@@ -27,6 +28,7 @@
     "OwO"
   ],
   "devDependencies": {
+    "@rollup/plugin-typescript": "^8.1.1",
     "@types/jest": "^26.0.14",
     "@typescript-eslint/eslint-plugin": "^4.14.1",
     "@typescript-eslint/parser": "^4.14.1",
@@ -40,10 +42,9 @@
   },
   "scripts": {
     "lint": "eslint **/src/**/*.ts",
-    "test": "npx jest",
+    "test": "jest",
     "serve": "nodemon",
-    "build": "npm run lint -- --fix && npm run test && tsc",
-    "prepare": "npm run build && rollup -c"
+    "build": "npm run lint -- --fix && npm run test && rollup -c"
   },
   "nodemonConfig": {
     "ignore": [
@@ -53,7 +54,6 @@
     "watch": [
       "src"
     ],
-    "exec": "npm run build",
-    "ext": "tsc"
+    "exec": "npm run build"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,9 +1,22 @@
+import typescript from '@rollup/plugin-typescript';
+
 export default [
     {
-        input: './dist/index.js',
+        input: 'src/index.ts',
         output: {
-            file: './dist/index.umd.js',
-            format: 'cjs',
+            // Workaround for generating declarations https://github.com/rollup/plugins/issues/105
+            dir: './',
+            entryFileNames: 'dist/index.js',
+            format: 'es',
         },
+        plugins: [typescript({ declaration: true, declarationDir: 'dist/', rootDir: 'src/' })]
+    },
+    {
+        input: 'src/index.ts',
+        output: { 
+            file: 'dist/index.cjs',
+            format: 'cjs'
+        },
+        plugins: [typescript()]
     },
 ]

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 import { getCapitalPercentage, InitModifierParam, isUri } from './utils';
 import { Seed } from './seed';
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 export const getRandomInt = (min: number, max: number): number => {
     min = Math.ceil(min);
     max = Math.floor(max);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES5",
-    "module": "commonjs",
-    "declaration": true,
-    "outDir": "./dist",
+    "target": "ES6",
     "strict": true,
     "experimentalDecorators": true
   },

--- a/umd.js
+++ b/umd.js
@@ -1,4 +1,0 @@
-import * as uwuifier from './src'
-const { Uwuifier, ...other } = uwuifier
-Object.assign(Uwuifier, other)
-Object.assign(window, { Uwuifier })


### PR DESCRIPTION
### Summary
I think the time has come to transition to ESModules and thereby drop support for UMD.

### Changes
- Remove UMD support in favor of ESM
- Rollup now handles the compiling for the .ts files
- Changed the compile target from ES5 to ES6
- Removed `'use strict';` from .ts files, because this is already specified in `tsconfig.json`

### Usage
#### Web
```html
<script type="module">
    import { Uwuifier } from 'Uwuifier';
    // or
    import { Uwuifier } from 'https://example.com/uwuifier.js';
</script>
```
#### NodeJS (ESM)
```javascript
import { Uwuifier } from 'Uwuifier';
```

#### NodeJS (CJS)
> Still supported
```javascript
const { Uwuifier } = require('Uwuifier');
```