### PR TITLE
ci: drop support for Node 10 & 12

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -19,14 +19,14 @@ jobs:
         run: deno fmt --check src/
 
       - name: Run deno lint
-        run: deno lint --unstable src/
+        run: deno lint src/
 
   Build:
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [14.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "typescript": "^4.2.3"
   },
   "scripts": {
-    "lint": "deno lint --unstable src/",
+    "lint": "deno lint src/",
     "format": "deno fmt src/",
     "test": "jest",
     "serve": "nodemon",
@@ -50,6 +50,9 @@
     "watch": [
       "src"
     ],
-    "exec": "npm run build"
+    "exec": "npm run build",
+    "engines": {
+      "node": ">=14"
+    }
   }
 }


### PR DESCRIPTION
Node v14 is now LTS.
Also remove --unstable flag from deno lint, since it's not needed anymore.